### PR TITLE
Update LICENSE to acknowledge CPLEX.jl

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,9 @@
+COPT.jl was based upon the wrapper developed in https://github.com/jump-dev/CPLEX.jl
+and subsequently modified by COPT-Public.
+
 MIT License
 
+Copyright (c) 2013 Joey Huchette and contributors
 Copyright (c) 2022 COPT-Public
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2013: Joey Huchette and contributors
+# Copyright (c) 2022: COPT-Public
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using Libdl
 
 const _DEPS_FILE = joinpath(dirname(@__FILE__), "deps.jl")

--- a/src/COPT.jl
+++ b/src/COPT.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2013: Joey Huchette and contributors
+# Copyright (c) 2022: COPT-Public
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module COPT
 
 include(joinpath(dirname(@__DIR__), "deps", "deps.jl"))

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2013: Joey Huchette and contributors
+# Copyright (c) 2022: COPT-Public
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 import MathOptInterface
 
 const MOI = MathOptInterface

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2013: Joey Huchette and contributors
+# Copyright (c) 2022: COPT-Public
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestMOIwrapper
 
 using COPT


### PR DESCRIPTION
You might also consider something like https://github.com/jump-dev/MathOptInterface.jl/pull/1813, which makes these sorts of acknowledgements a lot easier to track. (We've been a bit slack on this, but I'll get around to adding headers to all the JuMP-dev repos.)