### PR TITLE
6.5 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+# vscode
+.vscode/*

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,50 +1,50 @@
 [[copt]]
 arch = "aarch64"
 os = "linux"
-git-tree-sha1 = "23bb711e71d4d0154c78663298edb50eb9def1d6"
+git-tree-sha1 = "ee7307f9ee6bc22efd5a208279a7fada85d20b1b"
 lazy = true
 
     [[copt.download]]
-    url = "https://pub.shanshu.ai/download/copt/6.0.3/aarch64/CardinalOptimizer-6.0.3-aarch64_lnx.tar.gz"
-    sha256 = "2d6f674bd122c23dbfabbc5e3a19d7ff968ca59f3b20572112037d6da86ab651"
+    url = "https://pub.shanshu.ai/download/copt/6.5.3/aarch64/CardinalOptimizer-6.5.3-aarch64_lnx.tar.gz"
+    sha256 = "7b4830949328a2dfb869b0a9474cd11bfeec7cf53a9dcb53224cd345f14eed00"
 
 [[copt]]
 arch = "aarch64"
 os = "macos"
-git-tree-sha1 = "4f222144d9300d57c2cc0126672f756f10d6c18d"
+git-tree-sha1 = "cfa71fac5be653c73f2a68fba5dce6ed4f94b293"
 lazy = true
 
     [[copt.download]]
-    url = "https://pub.shanshu.ai/download/copt/6.0.3/aarch64/CardinalOptimizer-6.0.3-aarch64_mac.tar.gz"
-    sha256 = "efc91e8754343285e9e7b41301bb75e2fc344d777a3606241b0970964a2cf78c"
+    url = "https://pub.shanshu.ai/download/copt/6.5.3/aarch64/CardinalOptimizer-6.5.3-aarch64_mac.tar.gz"
+    sha256 = "8c2f01773f6770af287fbc5723eca4ff885618e278e42778178d03fbcec568d5"
 
 [[copt]]
 arch = "x86_64"
 os = "linux"
-git-tree-sha1 = "5cd8c22550f508b9a9f923a037c4fe63ff334838"
+git-tree-sha1 = "f176a7c239b836deaa00510bce750dbdea450e48"
 lazy = true
 
     [[copt.download]]
-    url = "https://pub.shanshu.ai/download/copt/6.0.3/linux64/CardinalOptimizer-6.0.3-lnx64.tar.gz"
-    sha256 = "c181379ffae7cfdd615060ccbe987ad52f6ea476eeb648bdb64af248c7ed579a"
+    url = "https://pub.shanshu.ai/download/copt/6.5.3/linux64/CardinalOptimizer-6.5.3-lnx64.tar.gz"
+    sha256 = "970704ad47080ecdb98ef66513e60c586221ecb6cc61a85803d742ce25fbff9f"
 
 [[copt]]
 arch = "x86_64"
 os = "macos"
-git-tree-sha1 = "61e978df78de80397c4c6c2a5cb36ea7779f1c53"
+git-tree-sha1 = "f6f9ed1feb4548dd90ceb65db53a2b032bbac83b"
 lazy = true
 
     [[copt.download]]
-    url = "https://pub.shanshu.ai/download/copt/6.0.3/osx64/CardinalOptimizer-6.0.3-osx64.tar.gz"
-    sha256 = "ce4fb3048a53586d5350bc1cf04b3d00fb79561e58a0528ba2f6f3ec7e60a603"
+    url = "https://pub.shanshu.ai/download/copt/6.5.3/osx64/CardinalOptimizer-6.5.3-osx64.tar.gz"
+    sha256 = "3a6ba498eac1aa8d17a65d9e3ef9149931c3b81ca368c548b8b3fbaf7b876b53"
 
 [[copt]]
 arch = "x86_64"
 os = "windows"
-git-tree-sha1 = "16a996c9e4ddb0fa50f6d0437ecede7741bac862"
+git-tree-sha1 = "2904e2730e94bdca618a96c5a89dbcaf70ee515b"
 lazy = true
 
     [[copt.download]]
-    url = "https://pub.shanshu.ai/download/copt/6.0.3/win64/CardinalOptimizer-6.0.3-win64.tar.gz"
-    sha256 = "d6212e9bc7fdf42f33d75ec71ca56a72ee1e295eb862e4232196e20fc18d8fc8"
+    url = "https://pub.shanshu.ai/download/copt/6.5.3/win64/CardinalOptimizer-6.5.3-win64.tar.gz"
+    sha256 = "4bfb8fb3dbde97be3bf3b8b39e9ae60ae12aec41db4e05d76dd3fed4350671eb"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,6 +15,7 @@ const _COPT_VERS = [ # From oldest to most recent.
     "40",
     "50",
     "60",
+    "65",
 ]
 const _COPT_HOME_ENV = "COPT_HOME"
 
@@ -52,6 +53,7 @@ function get_error_message_if_not_found()
     * 4.0
     * 5.0
     * 6.0
+    * 6.5
 
     You must download and install one of these versions separately.
 
@@ -60,7 +62,7 @@ function get_error_message_if_not_found()
     location):
 
     ```
-    ENV["COPT_HOME"] = "$(default_installation_path("copt60"))"
+    ENV["COPT_HOME"] = "$(default_installation_path("copt65"))"
     import Pkg
     Pkg.add("COPT")
     Pkg.build("COPT")

--- a/src/COPT.jl
+++ b/src/COPT.jl
@@ -101,6 +101,7 @@ end
 
 include("MOI/MOI_wrapper.jl")
 include("MOI/indicator_constraint.jl")
+include("MOI/callback.jl")
 
 # COPT exports all `COPT_xxx` and `copt_xxx` symbols. If you don't want all of
 # these symbols in your environment, then use `import COPT` instead of

--- a/src/COPT.jl
+++ b/src/COPT.jl
@@ -22,7 +22,7 @@ else
     # never get executed.
     @static if Sys.islinux() || Sys.isapple() || Sys.iswindows()
         # No local installation defined in deps.jl. Use the artifact instead.
-        coptdir = "copt60"
+        coptdir = "copt65"
         libdir = Sys.iswindows() ? "bin" : "lib"
         prefix = Sys.iswindows() ? "" : "lib"
         libname = prefix * "copt." * Libdl.dlext

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -2842,11 +2842,6 @@ function _check_moi_callback(model::Optimizer)
 end
 
 function _optimize!(model)
-    if _check_moi_callback(model) || model.has_generic_callback
-        println("Callback detected, set 'Threads' to '1' for thread safety")
-        MOI.set(model, MOI.RawOptimizerAttribute("Threads"), 1)
-    end
-
     if _has_discrete_variables(model)
         model.ret_optimize = COPT_Solve(model.prob)
         model.solved_as_mip = true

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -2842,6 +2842,11 @@ function _check_moi_callback(model::Optimizer)
 end
 
 function _optimize!(model)
+    if _check_moi_callback(model) || model.has_generic_callback
+        println("Callback detected, set 'Threads' to '1' for thread safety")
+        MOI.set(model, MOI.RawOptimizerAttribute("Threads"), 1)
+    end
+
     if _has_discrete_variables(model)
         model.ret_optimize = COPT_Solve(model.prob)
         model.solved_as_mip = true

--- a/src/MOI/callback.jl
+++ b/src/MOI/callback.jl
@@ -1,0 +1,304 @@
+# Copyright (c) 2023: COPT-Public
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+# ==============================================================================
+#    Generic Callbacks in COPT
+# ==============================================================================
+
+mutable struct CallbackData
+    model::Optimizer
+    ptr::Ptr{Cvoid}
+    cb_context::Cint
+end
+Base.cconvert(::Type{Ptr{Cvoid}}, x::CallbackData) = x
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::CallbackData) = x.ptr::Ptr{Cvoid}
+Base.broadcastable(x::CallbackData) = Ref(x)
+
+mutable struct _CallbackUserData
+    model::Optimizer
+    callback::Function
+end
+Base.cconvert(::Type{Ptr{Cvoid}}, x::_CallbackUserData) = x
+function Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::_CallbackUserData)
+    return pointer_from_objref(x)::Ptr{Cvoid}
+end
+
+function _copt_callback_wrapper(
+    p_model::Ptr{copt_prob},
+    cb_data::Ptr{Cvoid},
+    cb_context::Cint,
+    p_user_data::Ptr{Cvoid},
+)
+    user_data = unsafe_pointer_to_objref(p_user_data)::_CallbackUserData
+    try
+        user_data.callback(
+            CallbackData(user_data.model, cb_data, cb_context),
+            cb_context,
+        )
+    catch ex
+        COPT_Interrupt(p_model)
+        if !(ex isa InterruptException)
+            rethrow(ex)
+        end
+    end
+    return Cint(0)
+end
+
+"""
+    CallbackFunction()
+
+Set a generic COPT callback function.
+
+Callback function should be of the form
+
+    callback(cb_data::CallbackData, cb_context::Cint)
+
+Note: before accessing `MOI.CallbackVariablePrimal`, you must call
+`COPT.load_callback_variable_primal(cb_data, cb_context)`.
+"""
+struct CallbackFunction <: MOI.AbstractCallback end
+
+function MOI.set(model::Optimizer, ::CallbackFunction, f::Function)
+    copt_callback = @cfunction(
+        _copt_callback_wrapper,
+        Cint,
+        (Ptr{copt_prob}, Ptr{Cvoid}, Cint, Ptr{Cvoid})
+    )
+    user_data = _CallbackUserData(
+        model,
+        (cb_data, cb_context) -> begin
+            model.callback_state = _CB_GENERIC
+            f(cb_data, cb_context)
+            model.callback_state = _CB_NONE
+            return
+        end,
+    )
+    ret = COPT_SetCallback(
+        model.prob,
+        copt_callback,
+        COPT_CBCONTEXT_MIPRELAX | COPT_CBCONTEXT_MIPSOL,
+        user_data,
+    )
+    _check_ret(model, ret)
+    # We need to keep a reference to the callback function so that it isn't
+    # garbage collected.
+    model.generic_callback = user_data
+    model.has_generic_callback = true
+    return
+end
+MOI.supports(::Optimizer, ::CallbackFunction) = true
+
+"""
+    load_callback_variable_primal(cb_data, cb_context)
+
+Load the solution during a callback so that it can be accessed using
+`MOI.CallbackVariablePrimal`.
+"""
+function load_callback_variable_primal(cb_data::CallbackData, cb_context::Cint)
+    resize!(
+        cb_data.model.callback_variable_primal,
+        length(cb_data.model.variable_info),
+    )
+    if cb_context == COPT_CBCONTEXT_MIPRELAX
+        ret = COPT_GetCallbackInfo(
+            cb_data,
+            COPT_CBINFO_RELAXSOLUTION,
+            cb_data.model.callback_variable_primal,
+        )
+        _check_ret(cb_data.model, ret)
+    elseif cb_context == COPT_CBCONTEXT_MIPSOL
+        ret = COPT_GetCallbackInfo(
+            cb_data,
+            COPT_CBINFO_MIPCANDIDATE,
+            cb_data.model.callback_variable_primal,
+        )
+        _check_ret(cb_data.model, ret)
+    else
+        error(
+            "`load_callback_variable_primal` can only be called at " *
+            "COPT_CBCONTEXT_MIPRELAX or COPT_CBCONTEXT_MIPSOL.",
+        )
+    end
+    return
+end
+
+# ==============================================================================
+#    MOI callbacks
+# ==============================================================================
+
+function _default_moi_callback(model::Optimizer)
+    return (cb_data, cb_context) -> begin
+        if cb_context == COPT_CBCONTEXT_MIPSOL
+            load_callback_variable_primal(cb_data, cb_context)
+            if model.lazy_callback !== nothing
+                model.callback_state = _CB_LAZY
+                model.lazy_callback(cb_data)
+            end
+            if model.heuristic_callback !== nothing
+                model.callback_state = _CB_HEURISTIC
+                model.heuristic_callback(cb_data)
+            end
+        elseif cb_context == COPT_CBCONTEXT_MIPRELAX
+            load_callback_variable_primal(cb_data, cb_context)
+            if model.user_cut_callback !== nothing
+                model.callback_state = _CB_USER_CUT
+                model.user_cut_callback(cb_data)
+            end
+            if model.heuristic_callback !== nothing
+                model.callback_state = _CB_HEURISTIC
+                model.heuristic_callback(cb_data)
+            end
+            if model.lazy_callback !== nothing
+                model.callback_state = _CB_LAZY
+                model.lazy_callback(cb_data)
+            end
+        end
+        model.callback_state = _CB_NONE
+    end
+end
+
+function MOI.get(
+    model::Optimizer,
+    ::MOI.CallbackVariablePrimal{CallbackData},
+    x::MOI.VariableIndex,
+)
+    return model.callback_variable_primal[_info(model, x).column]
+end
+
+function MOI.get(::Optimizer, attr::MOI.CallbackNodeStatus{CallbackData})
+    if attr.callback_data.cb_context == COPT_CBCONTEXT_MIPSOL
+        return MOI.CALLBACK_NODE_STATUS_INTEGER
+    elseif attr.callback_data.cb_context == COPT_CBCONTEXT_MIPRELAX
+        return MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+    end
+    return MOI.CALLBACK_NODE_STATUS_UNKNOWN
+end
+
+# ==============================================================================
+#    MOI.LazyConstraint
+# ==============================================================================
+
+function MOI.set(model::Optimizer, ::MOI.LazyConstraintCallback, cb::Function)
+    model.lazy_callback = cb
+    return
+end
+MOI.supports(::Optimizer, ::MOI.LazyConstraintCallback) = true
+
+function MOI.submit(
+    model::Optimizer,
+    cb::MOI.LazyConstraint{CallbackData},
+    f::MOI.ScalarAffineFunction{Float64},
+    s::Union{
+        MOI.LessThan{Float64},
+        MOI.GreaterThan{Float64},
+        MOI.EqualTo{Float64},
+    },
+)
+    if model.callback_state == _CB_USER_CUT
+        throw(MOI.InvalidCallbackUsage(MOI.UserCutCallback(), cb))
+    elseif model.callback_state == _CB_HEURISTIC
+        throw(MOI.InvalidCallbackUsage(MOI.HeuristicCallback(), cb))
+    elseif !iszero(f.constant)
+        throw(
+            MOI.ScalarFunctionConstantNotZero{Float64,typeof(f),typeof(s)}(
+                f.constant,
+            ),
+        )
+    end
+    indices, coefficients = _indices_and_coefficients(model, f)
+    sense, rhs = _sense_and_rhs(s)
+    ret = COPT_AddCallbackLazyConstr(
+        cb.callback_data,
+        length(indices),
+        indices,
+        coefficients,
+        sense,
+        rhs,
+    )
+    _check_ret(model, ret)
+    return
+end
+MOI.supports(::Optimizer, ::MOI.LazyConstraint{CallbackData}) = true
+
+# ==============================================================================
+#    MOI.UserCutCallback
+# ==============================================================================
+
+function MOI.set(model::Optimizer, ::MOI.UserCutCallback, cb::Function)
+    model.user_cut_callback = cb
+    return
+end
+MOI.supports(::Optimizer, ::MOI.UserCutCallback) = true
+
+function MOI.submit(
+    model::Optimizer,
+    cb::MOI.UserCut{CallbackData},
+    f::MOI.ScalarAffineFunction{Float64},
+    s::Union{
+        MOI.LessThan{Float64},
+        MOI.GreaterThan{Float64},
+        MOI.EqualTo{Float64},
+    },
+)
+    if model.callback_state == _CB_LAZY
+        throw(MOI.InvalidCallbackUsage(MOI.LazyConstraintCallback(), cb))
+    elseif model.callback_state == _CB_HEURISTIC
+        throw(MOI.InvalidCallbackUsage(MOI.HeuristicCallback(), cb))
+    elseif !iszero(f.constant)
+        throw(
+            MOI.ScalarFunctionConstantNotZero{Float64,typeof(f),typeof(s)}(
+                f.constant,
+            ),
+        )
+    end
+    indices, coefficients = _indices_and_coefficients(model, f)
+    sense, rhs = _sense_and_rhs(s)
+    ret = COPT_AddCallbackUserCut(
+        cb.callback_data,
+        length(indices),
+        indices,
+        coefficients,
+        sense,
+        rhs,
+    )
+    _check_ret(model, ret)
+    return
+end
+MOI.supports(::Optimizer, ::MOI.UserCut{CallbackData}) = true
+
+# ==============================================================================
+#    MOI.HeuristicCallback
+# ==============================================================================
+
+function MOI.set(model::Optimizer, ::MOI.HeuristicCallback, cb::Function)
+    model.heuristic_callback = cb
+    return
+end
+MOI.supports(::Optimizer, ::MOI.HeuristicCallback) = true
+
+function MOI.submit(
+    model::Optimizer,
+    cb::MOI.HeuristicSolution{CallbackData},
+    variables::Vector{MOI.VariableIndex},
+    values::MOI.Vector{Float64},
+)
+    if model.callback_state == _CB_LAZY
+        throw(MOI.InvalidCallbackUsage(MOI.LazyConstraintCallback(), cb))
+    elseif model.callback_state == _CB_USER_CUT
+        throw(MOI.InvalidCallbackUsage(MOI.UserCutCallback(), cb))
+    end
+    solution = fill(COPT_UNDEFINED, MOI.get(model, MOI.NumberOfVariables()))
+    for (var, value) in zip(variables, values)
+        solution[_info(model, var).column] = value
+    end
+    objP = Ref{Cdouble}()
+    ret = COPT_AddCallbackSolution(cb.callback_data, solution, objP)
+    _check_ret(model, ret)
+    if objP[] < COPT_INFINITY
+        return MOI.HEURISTIC_SOLUTION_ACCEPTED
+    end
+    return MOI.HEURISTIC_SOLUTION_UNKNOWN
+end
+MOI.supports(::Optimizer, ::MOI.HeuristicSolution{CallbackData}) = true

--- a/src/MOI/callback.jl
+++ b/src/MOI/callback.jl
@@ -296,9 +296,6 @@ function MOI.submit(
     objP = Ref{Cdouble}()
     ret = COPT_AddCallbackSolution(cb.callback_data, solution, objP)
     _check_ret(model, ret)
-    if objP[] < COPT_INFINITY
-        return MOI.HEURISTIC_SOLUTION_ACCEPTED
-    end
     return MOI.HEURISTIC_SOLUTION_UNKNOWN
 end
 MOI.supports(::Optimizer, ::MOI.HeuristicSolution{CallbackData}) = true

--- a/src/MOI/callback.jl
+++ b/src/MOI/callback.jl
@@ -61,14 +61,6 @@ Note: before accessing `MOI.CallbackVariablePrimal`, you must call
 struct CallbackFunction <: MOI.AbstractCallback end
 
 function MOI.set(model::Optimizer, ::CallbackFunction, f::Function)
-    if MOI.get(model, MOI.NumberOfThreads()) != 1
-        @warn(
-            "When using callbacks, make sure to set `NumberOfThreads` to `1` " *
-            "using `MOI.set(model, MOI.NumberOfThreads(), 1)`. Bad things can" *
-            " happen if you don't! Only ignore this message if you know what " *
-            "you are doing."
-        )
-    end
     copt_callback = @cfunction(
         _copt_callback_wrapper,
         Cint,
@@ -137,13 +129,6 @@ end
 # ==============================================================================
 
 function _default_moi_callback(model::Optimizer)
-    if MOI.get(model, MOI.NumberOfThreads()) != 1
-        # The current callback system isn't thread-safe. As a work-around, set
-        # the number of threads to 1, regardless of what the user intended.
-        # We only do this for the MOI callbacks, since we assume the user knows
-        # what they are doing if they use a solver-dependent callback.
-        MOI.set(model, MOI.NumberOfThreads(), 1)
-    end
     return (cb_data, cb_context) -> begin
         if cb_context == COPT_CBCONTEXT_MIPSOL
             load_callback_variable_primal(cb_data, cb_context)

--- a/src/gen6.5.3/libcopt.jl
+++ b/src/gen6.5.3/libcopt.jl
@@ -1,0 +1,1040 @@
+mutable struct copt_env_config_s end
+
+const copt_env_config = copt_env_config_s
+
+mutable struct copt_env_s end
+
+const copt_env = copt_env_s
+
+mutable struct copt_prob_s end
+
+const copt_prob = copt_prob_s
+
+function COPT_GetBanner(buff, buffSize)
+    ccall((:COPT_GetBanner, libcopt), Cint, (Ptr{Cchar}, Cint), buff, buffSize)
+end
+
+function COPT_GetRetcodeMsg(code, buff, buffSize)
+    ccall((:COPT_GetRetcodeMsg, libcopt), Cint, (Cint, Ptr{Cchar}, Cint), code, buff, buffSize)
+end
+
+function COPT_CreateEnvConfig(p_config)
+    ccall((:COPT_CreateEnvConfig, libcopt), Cint, (Ptr{Ptr{copt_env_config}},), p_config)
+end
+
+function COPT_DeleteEnvConfig(p_config)
+    ccall((:COPT_DeleteEnvConfig, libcopt), Cint, (Ptr{Ptr{copt_env_config}},), p_config)
+end
+
+function COPT_SetEnvConfig(config, name, value)
+    ccall((:COPT_SetEnvConfig, libcopt), Cint, (Ptr{copt_env_config}, Ptr{Cchar}, Ptr{Cchar}), config, name, value)
+end
+
+function COPT_CreateEnv(p_env)
+    ccall((:COPT_CreateEnv, libcopt), Cint, (Ptr{Ptr{copt_env}},), p_env)
+end
+
+function COPT_CreateEnvWithPath(licDir, p_env)
+    ccall((:COPT_CreateEnvWithPath, libcopt), Cint, (Ptr{Cchar}, Ptr{Ptr{copt_env}}), licDir, p_env)
+end
+
+function COPT_CreateEnvWithConfig(config, p_env)
+    ccall((:COPT_CreateEnvWithConfig, libcopt), Cint, (Ptr{copt_env_config}, Ptr{Ptr{copt_env}}), config, p_env)
+end
+
+function COPT_CloseEnv(p_env)
+    ccall((:COPT_CloseEnv, libcopt), Cint, (Ptr{Ptr{copt_env}},), p_env)
+end
+
+function COPT_DeleteEnv(p_env)
+    ccall((:COPT_DeleteEnv, libcopt), Cint, (Ptr{Ptr{copt_env}},), p_env)
+end
+
+function COPT_GetLicenseMsg(env, buff, buffSize)
+    ccall((:COPT_GetLicenseMsg, libcopt), Cint, (Ptr{copt_env}, Ptr{Cchar}, Cint), env, buff, buffSize)
+end
+
+function COPT_CreateProb(env, p_prob)
+    ccall((:COPT_CreateProb, libcopt), Cint, (Ptr{copt_env}, Ptr{Ptr{copt_prob}}), env, p_prob)
+end
+
+function COPT_CreateCopy(src_prob, p_dst_prob)
+    ccall((:COPT_CreateCopy, libcopt), Cint, (Ptr{copt_prob}, Ptr{Ptr{copt_prob}}), src_prob, p_dst_prob)
+end
+
+function COPT_DeleteProb(p_prob)
+    ccall((:COPT_DeleteProb, libcopt), Cint, (Ptr{Ptr{copt_prob}},), p_prob)
+end
+
+function COPT_LoadProb(prob, nCol, nRow, iObjSense, dObjConst, colObj, colMatBeg, colMatCnt, colMatIdx, colMatElem, colType, colLower, colUpper, rowSense, rowBound, rowUpper, colNames, rowNames)
+    ccall((:COPT_LoadProb, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint, Cint, Cdouble, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Ptr{Cchar}}, Ptr{Ptr{Cchar}}), prob, nCol, nRow, iObjSense, dObjConst, colObj, colMatBeg, colMatCnt, colMatIdx, colMatElem, colType, colLower, colUpper, rowSense, rowBound, rowUpper, colNames, rowNames)
+end
+
+function COPT_AddCol(prob, dColObj, nColMatCnt, colMatIdx, colMatElem, cColType, dColLower, dColUpper, colName)
+    ccall((:COPT_AddCol, libcopt), Cint, (Ptr{copt_prob}, Cdouble, Cint, Ptr{Cint}, Ptr{Cdouble}, Cchar, Cdouble, Cdouble, Ptr{Cchar}), prob, dColObj, nColMatCnt, colMatIdx, colMatElem, cColType, dColLower, dColUpper, colName)
+end
+
+function COPT_AddPSDCol(prob, colDim, name)
+    ccall((:COPT_AddPSDCol, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cchar}), prob, colDim, name)
+end
+
+function COPT_AddRow(prob, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound, dRowUpper, rowName)
+    ccall((:COPT_AddRow, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cchar, Cdouble, Cdouble, Ptr{Cchar}), prob, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound, dRowUpper, rowName)
+end
+
+function COPT_AddCols(prob, nAddCol, colObj, colMatBeg, colMatCnt, colMatIdx, colMatElem, colType, colLower, colUpper, colNames)
+    ccall((:COPT_AddCols, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Ptr{Cchar}}), prob, nAddCol, colObj, colMatBeg, colMatCnt, colMatIdx, colMatElem, colType, colLower, colUpper, colNames)
+end
+
+function COPT_AddPSDCols(prob, nAddCol, colDims, names)
+    ccall((:COPT_AddPSDCols, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Ptr{Cchar}}), prob, nAddCol, colDims, names)
+end
+
+function COPT_AddRows(prob, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowBound, rowUpper, rowNames)
+    ccall((:COPT_AddRows, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Ptr{Cchar}}), prob, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowBound, rowUpper, rowNames)
+end
+
+function COPT_AddLazyConstr(prob, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound, dRowUpper, rowName)
+    ccall((:COPT_AddLazyConstr, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cchar, Cdouble, Cdouble, Ptr{Cchar}), prob, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound, dRowUpper, rowName)
+end
+
+function COPT_AddLazyConstrs(prob, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowBound, rowUpper, rowNames)
+    ccall((:COPT_AddLazyConstrs, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Ptr{Cchar}}), prob, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowBound, rowUpper, rowNames)
+end
+
+function COPT_AddUserCut(prob, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound, dRowUpper, rowName)
+    ccall((:COPT_AddUserCut, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cchar, Cdouble, Cdouble, Ptr{Cchar}), prob, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound, dRowUpper, rowName)
+end
+
+function COPT_AddUserCuts(prob, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowBound, rowUpper, rowNames)
+    ccall((:COPT_AddUserCuts, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Ptr{Cchar}}), prob, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowBound, rowUpper, rowNames)
+end
+
+function COPT_AddSOSs(prob, nAddSOS, sosType, sosMatBeg, sosMatCnt, sosMatIdx, sosMatWt)
+    ccall((:COPT_AddSOSs, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}), prob, nAddSOS, sosType, sosMatBeg, sosMatCnt, sosMatIdx, sosMatWt)
+end
+
+function COPT_AddCones(prob, nAddCone, coneType, coneBeg, coneCnt, coneIdx)
+    ccall((:COPT_AddCones, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), prob, nAddCone, coneType, coneBeg, coneCnt, coneIdx)
+end
+
+function COPT_AddQConstr(prob, nRowMatCnt, rowMatIdx, rowMatElem, nQMatCnt, qMatRow, qMatCol, qMatElem, cRowsense, dRowBound, name)
+    ccall((:COPT_AddQConstr, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cchar, Cdouble, Ptr{Cchar}), prob, nRowMatCnt, rowMatIdx, rowMatElem, nQMatCnt, qMatRow, qMatCol, qMatElem, cRowsense, dRowBound, name)
+end
+
+function COPT_AddPSDConstr(prob, nRowMatCnt, rowMatIdx, rowMatElem, nColCnt, psdColIdx, symMatIdx, cRowSense, dRowBound, dRowUpper, name)
+    ccall((:COPT_AddPSDConstr, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cint}, Cchar, Cdouble, Cdouble, Ptr{Cchar}), prob, nRowMatCnt, rowMatIdx, rowMatElem, nColCnt, psdColIdx, symMatIdx, cRowSense, dRowBound, dRowUpper, name)
+end
+
+function COPT_AddIndicator(prob, binColIdx, binColVal, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound)
+    ccall((:COPT_AddIndicator, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}, Cchar, Cdouble), prob, binColIdx, binColVal, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound)
+end
+
+function COPT_GetCols(prob, nCol, list, colMatBeg, colMatCnt, colMatIdx, colMatElem, nElemSize, pReqSize)
+    ccall((:COPT_GetCols, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}), prob, nCol, list, colMatBeg, colMatCnt, colMatIdx, colMatElem, nElemSize, pReqSize)
+end
+
+function COPT_GetPSDCols(prob, nCol, list, colDims, colLens)
+    ccall((:COPT_GetPSDCols, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), prob, nCol, list, colDims, colLens)
+end
+
+function COPT_GetRows(prob, nRow, list, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, nElemSize, pReqSize)
+    ccall((:COPT_GetRows, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}), prob, nRow, list, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, nElemSize, pReqSize)
+end
+
+function COPT_GetSOSs(prob, nSos, list, sosType, sosMatBeg, sosMatCnt, sosMatIdx, sosMatWt, nElemSize, pReqSize)
+    ccall((:COPT_GetSOSs, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}), prob, nSos, list, sosType, sosMatBeg, sosMatCnt, sosMatIdx, sosMatWt, nElemSize, pReqSize)
+end
+
+function COPT_GetCones(prob, nCone, list, coneType, coneBeg, coneCnt, coneIdx, nElemSize, pReqSize)
+    ccall((:COPT_GetCones, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Cint, Ptr{Cint}), prob, nCone, list, coneType, coneBeg, coneCnt, coneIdx, nElemSize, pReqSize)
+end
+
+function COPT_GetQConstr(prob, qConstrIdx, qMatRow, qMatCol, qMatElem, nQElemSize, pQReqSize, rowMatIdx, rowMatElem, cRowSense, dRowBound, nElemSize, pReqSize)
+    ccall((:COPT_GetQConstr, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}, Cint, Ptr{Cint}), prob, qConstrIdx, qMatRow, qMatCol, qMatElem, nQElemSize, pQReqSize, rowMatIdx, rowMatElem, cRowSense, dRowBound, nElemSize, pReqSize)
+end
+
+function COPT_GetPSDConstr(prob, psdConstrIdx, psdColIdx, symMatIdx, nColSize, pColReqSize, rowMatIdx, rowMatElem, dRowLower, dRowUpper, nElemSize, pReqSize)
+    ccall((:COPT_GetPSDConstr, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cint}), prob, psdConstrIdx, psdColIdx, symMatIdx, nColSize, pColReqSize, rowMatIdx, rowMatElem, dRowLower, dRowUpper, nElemSize, pReqSize)
+end
+
+function COPT_GetIndicator(prob, rowIdx, binColIdx, binColVal, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound, nElemSize, pReqSize)
+    ccall((:COPT_GetIndicator, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}, Cint, Ptr{Cint}), prob, rowIdx, binColIdx, binColVal, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowBound, nElemSize, pReqSize)
+end
+
+function COPT_GetElem(prob, iCol, iRow, p_elem)
+    ccall((:COPT_GetElem, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint, Ptr{Cdouble}), prob, iCol, iRow, p_elem)
+end
+
+function COPT_SetElem(prob, iCol, iRow, newElem)
+    ccall((:COPT_SetElem, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint, Cdouble), prob, iCol, iRow, newElem)
+end
+
+function COPT_GetPSDElem(prob, iCol, iRow, p_idx)
+    ccall((:COPT_GetPSDElem, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint, Ptr{Cint}), prob, iCol, iRow, p_idx)
+end
+
+function COPT_SetPSDElem(prob, iCol, iRow, newIdx)
+    ccall((:COPT_SetPSDElem, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint, Cint), prob, iCol, iRow, newIdx)
+end
+
+function COPT_DelCols(prob, num, list)
+    ccall((:COPT_DelCols, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, num, list)
+end
+
+function COPT_DelPSDCols(prob, num, list)
+    ccall((:COPT_DelPSDCols, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, num, list)
+end
+
+function COPT_DelRows(prob, num, list)
+    ccall((:COPT_DelRows, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, num, list)
+end
+
+function COPT_DelSOSs(prob, num, list)
+    ccall((:COPT_DelSOSs, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, num, list)
+end
+
+function COPT_DelCones(prob, num, list)
+    ccall((:COPT_DelCones, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, num, list)
+end
+
+function COPT_DelQConstrs(prob, num, list)
+    ccall((:COPT_DelQConstrs, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, num, list)
+end
+
+function COPT_DelPSDConstrs(prob, num, list)
+    ccall((:COPT_DelPSDConstrs, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, num, list)
+end
+
+function COPT_DelIndicators(prob, num, list)
+    ccall((:COPT_DelIndicators, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, num, list)
+end
+
+function COPT_SetQuadObj(prob, num, qRow, qCol, qElem)
+    ccall((:COPT_SetQuadObj, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}), prob, num, qRow, qCol, qElem)
+end
+
+function COPT_GetQuadObj(prob, p_nQElem, qRow, qCol, qElem)
+    ccall((:COPT_GetQuadObj, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}), prob, p_nQElem, qRow, qCol, qElem)
+end
+
+function COPT_DelQuadObj(prob)
+    ccall((:COPT_DelQuadObj, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+function COPT_SetPSDObj(prob, iCol, newIdx)
+    ccall((:COPT_SetPSDObj, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint), prob, iCol, newIdx)
+end
+
+function COPT_GetPSDObj(prob, iCol, p_idx)
+    ccall((:COPT_GetPSDObj, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}), prob, iCol, p_idx)
+end
+
+function COPT_DelPSDObj(prob)
+    ccall((:COPT_DelPSDObj, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+function COPT_AddSymMat(prob, ndim, nelem, rows, cols, elems)
+    ccall((:COPT_AddSymMat, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}), prob, ndim, nelem, rows, cols, elems)
+end
+
+function COPT_GetSymMat(prob, iMat, p_nDim, p_nElem, rows, cols, elems)
+    ccall((:COPT_GetSymMat, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}), prob, iMat, p_nDim, p_nElem, rows, cols, elems)
+end
+
+function COPT_SetObjSense(prob, iObjSense)
+    ccall((:COPT_SetObjSense, libcopt), Cint, (Ptr{copt_prob}, Cint), prob, iObjSense)
+end
+
+function COPT_SetObjConst(prob, dObjConst)
+    ccall((:COPT_SetObjConst, libcopt), Cint, (Ptr{copt_prob}, Cdouble), prob, dObjConst)
+end
+
+function COPT_SetColObj(prob, num, list, obj)
+    ccall((:COPT_SetColObj, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, obj)
+end
+
+function COPT_SetColType(prob, num, list, type)
+    ccall((:COPT_SetColType, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cchar}), prob, num, list, type)
+end
+
+function COPT_SetColLower(prob, num, list, lower)
+    ccall((:COPT_SetColLower, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, lower)
+end
+
+function COPT_SetColUpper(prob, num, list, upper)
+    ccall((:COPT_SetColUpper, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, upper)
+end
+
+function COPT_SetColNames(prob, num, list, names)
+    ccall((:COPT_SetColNames, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Ptr{Cchar}}), prob, num, list, names)
+end
+
+function COPT_SetPSDColNames(prob, num, list, names)
+    ccall((:COPT_SetPSDColNames, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Ptr{Cchar}}), prob, num, list, names)
+end
+
+function COPT_SetRowLower(prob, num, list, lower)
+    ccall((:COPT_SetRowLower, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, lower)
+end
+
+function COPT_SetRowUpper(prob, num, list, upper)
+    ccall((:COPT_SetRowUpper, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, upper)
+end
+
+function COPT_SetRowNames(prob, num, list, names)
+    ccall((:COPT_SetRowNames, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Ptr{Cchar}}), prob, num, list, names)
+end
+
+function COPT_SetQConstrSense(prob, num, list, sense)
+    ccall((:COPT_SetQConstrSense, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cchar}), prob, num, list, sense)
+end
+
+function COPT_SetQConstrRhs(prob, num, list, rhs)
+    ccall((:COPT_SetQConstrRhs, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, rhs)
+end
+
+function COPT_SetQConstrNames(prob, num, list, names)
+    ccall((:COPT_SetQConstrNames, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Ptr{Cchar}}), prob, num, list, names)
+end
+
+function COPT_SetPSDConstrLower(prob, num, list, lower)
+    ccall((:COPT_SetPSDConstrLower, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, lower)
+end
+
+function COPT_SetPSDConstrUpper(prob, num, list, upper)
+    ccall((:COPT_SetPSDConstrUpper, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, upper)
+end
+
+function COPT_SetPSDConstrNames(prob, num, list, names)
+    ccall((:COPT_SetPSDConstrNames, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Ptr{Cchar}}), prob, num, list, names)
+end
+
+function COPT_ReplaceColObj(prob, num, list, obj)
+    ccall((:COPT_ReplaceColObj, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, obj)
+end
+
+function COPT_ReplacePSDObj(prob, num, list, idx)
+    ccall((:COPT_ReplacePSDObj, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, idx)
+end
+
+function COPT_ReadMps(prob, mpsfilename)
+    ccall((:COPT_ReadMps, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, mpsfilename)
+end
+
+function COPT_ReadLp(prob, lpfilename)
+    ccall((:COPT_ReadLp, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, lpfilename)
+end
+
+function COPT_ReadSDPA(prob, sdpafilename)
+    ccall((:COPT_ReadSDPA, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, sdpafilename)
+end
+
+function COPT_ReadCbf(prob, cbffilename)
+    ccall((:COPT_ReadCbf, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, cbffilename)
+end
+
+function COPT_ReadBin(prob, binfilename)
+    ccall((:COPT_ReadBin, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, binfilename)
+end
+
+function COPT_ReadSol(prob, solfilename)
+    ccall((:COPT_ReadSol, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, solfilename)
+end
+
+function COPT_ReadBasis(prob, basfilename)
+    ccall((:COPT_ReadBasis, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, basfilename)
+end
+
+function COPT_ReadMst(prob, mstfilename)
+    ccall((:COPT_ReadMst, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, mstfilename)
+end
+
+function COPT_ReadParam(prob, parfilename)
+    ccall((:COPT_ReadParam, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, parfilename)
+end
+
+function COPT_ReadParamStr(prob, strParam)
+    ccall((:COPT_ReadParamStr, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, strParam)
+end
+
+function COPT_ReadTune(prob, tunefilename)
+    ccall((:COPT_ReadTune, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, tunefilename)
+end
+
+function COPT_ReadBlob(prob, blob, len)
+    ccall((:COPT_ReadBlob, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cvoid}, Clong), prob, blob, len)
+end
+
+function COPT_WriteMps(prob, mpsfilename)
+    ccall((:COPT_WriteMps, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, mpsfilename)
+end
+
+function COPT_WriteLp(prob, lpfilename)
+    ccall((:COPT_WriteLp, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, lpfilename)
+end
+
+function COPT_WriteCbf(prob, cbffilename)
+    ccall((:COPT_WriteCbf, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, cbffilename)
+end
+
+function COPT_WriteBin(prob, binfilename)
+    ccall((:COPT_WriteBin, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, binfilename)
+end
+
+function COPT_WriteIIS(prob, iisfilename)
+    ccall((:COPT_WriteIIS, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, iisfilename)
+end
+
+function COPT_WriteRelax(prob, relaxfilename)
+    ccall((:COPT_WriteRelax, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, relaxfilename)
+end
+
+function COPT_WriteSol(prob, solfilename)
+    ccall((:COPT_WriteSol, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, solfilename)
+end
+
+function COPT_WritePoolSol(prob, iSol, solfilename)
+    ccall((:COPT_WritePoolSol, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cchar}), prob, iSol, solfilename)
+end
+
+function COPT_WriteBasis(prob, basfilename)
+    ccall((:COPT_WriteBasis, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, basfilename)
+end
+
+function COPT_WriteMst(prob, mstfilename)
+    ccall((:COPT_WriteMst, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, mstfilename)
+end
+
+function COPT_WriteParam(prob, parfilename)
+    ccall((:COPT_WriteParam, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, parfilename)
+end
+
+function COPT_WriteTuneParam(prob, idx, parfilename)
+    ccall((:COPT_WriteTuneParam, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cchar}), prob, idx, parfilename)
+end
+
+function COPT_WriteMpsStr(prob, str, nStrSize, pReqSize)
+    ccall((:COPT_WriteMpsStr, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cint, Ptr{Cint}), prob, str, nStrSize, pReqSize)
+end
+
+function COPT_WriteParamStr(prob, str, nStrSize, pReqSize)
+    ccall((:COPT_WriteParamStr, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cint, Ptr{Cint}), prob, str, nStrSize, pReqSize)
+end
+
+function COPT_WriteBlob(prob, tryCompress, p_blob, pLen)
+    ccall((:COPT_WriteBlob, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Ptr{Cvoid}}, Ptr{Clong}), prob, tryCompress, p_blob, pLen)
+end
+
+function COPT_AddMipStart(prob, num, list, colVal)
+    ccall((:COPT_AddMipStart, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, colVal)
+end
+
+function COPT_SolveLp(prob)
+    ccall((:COPT_SolveLp, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+function COPT_Solve(prob)
+    ccall((:COPT_Solve, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+function COPT_ComputeIIS(prob)
+    ccall((:COPT_ComputeIIS, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+function COPT_FeasRelax(prob, colLowPen, colUppPen, rowBndPen, rowUppPen)
+    ccall((:COPT_FeasRelax, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), prob, colLowPen, colUppPen, rowBndPen, rowUppPen)
+end
+
+function COPT_Tune(prob)
+    ccall((:COPT_Tune, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+function COPT_LoadTuneParam(prob, idx)
+    ccall((:COPT_LoadTuneParam, libcopt), Cint, (Ptr{copt_prob}, Cint), prob, idx)
+end
+
+function COPT_GetSolution(prob, colVal)
+    ccall((:COPT_GetSolution, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cdouble}), prob, colVal)
+end
+
+function COPT_GetLpSolution(prob, value, slack, rowDual, redCost)
+    ccall((:COPT_GetLpSolution, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), prob, value, slack, rowDual, redCost)
+end
+
+function COPT_SetLpSolution(prob, value, slack, rowDual, redCost)
+    ccall((:COPT_SetLpSolution, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), prob, value, slack, rowDual, redCost)
+end
+
+function COPT_GetBasis(prob, colBasis, rowBasis)
+    ccall((:COPT_GetBasis, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cint}, Ptr{Cint}), prob, colBasis, rowBasis)
+end
+
+function COPT_SetBasis(prob, colBasis, rowBasis)
+    ccall((:COPT_SetBasis, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cint}, Ptr{Cint}), prob, colBasis, rowBasis)
+end
+
+function COPT_SetSlackBasis(prob)
+    ccall((:COPT_SetSlackBasis, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+function COPT_GetPoolObjVal(prob, iSol, p_objVal)
+    ccall((:COPT_GetPoolObjVal, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cdouble}), prob, iSol, p_objVal)
+end
+
+function COPT_GetPoolSolution(prob, iSol, num, list, colVal)
+    ccall((:COPT_GetPoolSolution, libcopt), Cint, (Ptr{copt_prob}, Cint, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, iSol, num, list, colVal)
+end
+
+function COPT_SetIntParam(prob, paramName, intParam)
+    ccall((:COPT_SetIntParam, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cint), prob, paramName, intParam)
+end
+
+function COPT_GetIntParam(prob, paramName, p_intParam)
+    ccall((:COPT_GetIntParam, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, paramName, p_intParam)
+end
+
+function COPT_GetIntParamDef(prob, paramName, p_intParam)
+    ccall((:COPT_GetIntParamDef, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, paramName, p_intParam)
+end
+
+function COPT_GetIntParamMin(prob, paramName, p_intParam)
+    ccall((:COPT_GetIntParamMin, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, paramName, p_intParam)
+end
+
+function COPT_GetIntParamMax(prob, paramName, p_intParam)
+    ccall((:COPT_GetIntParamMax, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, paramName, p_intParam)
+end
+
+function COPT_SetDblParam(prob, paramName, dblParam)
+    ccall((:COPT_SetDblParam, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cdouble), prob, paramName, dblParam)
+end
+
+function COPT_GetDblParam(prob, paramName, p_dblParam)
+    ccall((:COPT_GetDblParam, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cdouble}), prob, paramName, p_dblParam)
+end
+
+function COPT_GetDblParamDef(prob, paramName, p_dblParam)
+    ccall((:COPT_GetDblParamDef, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cdouble}), prob, paramName, p_dblParam)
+end
+
+function COPT_GetDblParamMin(prob, paramName, p_dblParam)
+    ccall((:COPT_GetDblParamMin, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cdouble}), prob, paramName, p_dblParam)
+end
+
+function COPT_GetDblParamMax(prob, paramName, p_dblParam)
+    ccall((:COPT_GetDblParamMax, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cdouble}), prob, paramName, p_dblParam)
+end
+
+function COPT_ResetParam(prob)
+    ccall((:COPT_ResetParam, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+function COPT_Reset(prob, iClearAll)
+    ccall((:COPT_Reset, libcopt), Cint, (Ptr{copt_prob}, Cint), prob, iClearAll)
+end
+
+function COPT_GetIntAttr(prob, attrName, p_intAttr)
+    ccall((:COPT_GetIntAttr, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, attrName, p_intAttr)
+end
+
+function COPT_GetDblAttr(prob, attrName, p_dblAttr)
+    ccall((:COPT_GetDblAttr, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cdouble}), prob, attrName, p_dblAttr)
+end
+
+function COPT_GetColIdx(prob, colName, p_iCol)
+    ccall((:COPT_GetColIdx, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, colName, p_iCol)
+end
+
+function COPT_GetPSDColIdx(prob, psdColName, p_iPSDCol)
+    ccall((:COPT_GetPSDColIdx, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, psdColName, p_iPSDCol)
+end
+
+function COPT_GetRowIdx(prob, rowName, p_iRow)
+    ccall((:COPT_GetRowIdx, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, rowName, p_iRow)
+end
+
+function COPT_GetQConstrIdx(prob, qConstrName, p_iQConstr)
+    ccall((:COPT_GetQConstrIdx, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, qConstrName, p_iQConstr)
+end
+
+function COPT_GetPSDConstrIdx(prob, psdConstrName, p_iPSDConstr)
+    ccall((:COPT_GetPSDConstrIdx, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Ptr{Cint}), prob, psdConstrName, p_iPSDConstr)
+end
+
+function COPT_GetColInfo(prob, infoName, num, list, info)
+    ccall((:COPT_GetColInfo, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, infoName, num, list, info)
+end
+
+function COPT_GetPSDColInfo(prob, infoName, iCol, info)
+    ccall((:COPT_GetPSDColInfo, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cint, Ptr{Cdouble}), prob, infoName, iCol, info)
+end
+
+function COPT_GetRowInfo(prob, infoName, num, list, info)
+    ccall((:COPT_GetRowInfo, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, infoName, num, list, info)
+end
+
+function COPT_GetQConstrInfo(prob, infoName, num, list, info)
+    ccall((:COPT_GetQConstrInfo, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, infoName, num, list, info)
+end
+
+function COPT_GetPSDConstrInfo(prob, infoName, num, list, info)
+    ccall((:COPT_GetPSDConstrInfo, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, infoName, num, list, info)
+end
+
+function COPT_GetColType(prob, num, list, type)
+    ccall((:COPT_GetColType, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cchar}), prob, num, list, type)
+end
+
+function COPT_GetColBasis(prob, num, list, colBasis)
+    ccall((:COPT_GetColBasis, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, colBasis)
+end
+
+function COPT_GetRowBasis(prob, num, list, rowBasis)
+    ccall((:COPT_GetRowBasis, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, rowBasis)
+end
+
+function COPT_GetQConstrSense(prob, num, list, sense)
+    ccall((:COPT_GetQConstrSense, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cchar}), prob, num, list, sense)
+end
+
+function COPT_GetQConstrRhs(prob, num, list, rhs)
+    ccall((:COPT_GetQConstrRhs, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cdouble}), prob, num, list, rhs)
+end
+
+function COPT_GetColLowerIIS(prob, num, list, colLowerIIS)
+    ccall((:COPT_GetColLowerIIS, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, colLowerIIS)
+end
+
+function COPT_GetColUpperIIS(prob, num, list, colUpperIIS)
+    ccall((:COPT_GetColUpperIIS, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, colUpperIIS)
+end
+
+function COPT_GetRowLowerIIS(prob, num, list, rowLowerIIS)
+    ccall((:COPT_GetRowLowerIIS, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, rowLowerIIS)
+end
+
+function COPT_GetRowUpperIIS(prob, num, list, rowUpperIIS)
+    ccall((:COPT_GetRowUpperIIS, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, rowUpperIIS)
+end
+
+function COPT_GetSOSIIS(prob, num, list, sosIIS)
+    ccall((:COPT_GetSOSIIS, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, sosIIS)
+end
+
+function COPT_GetIndicatorIIS(prob, num, list, indicatorIIS)
+    ccall((:COPT_GetIndicatorIIS, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cint}, Ptr{Cint}), prob, num, list, indicatorIIS)
+end
+
+function COPT_GetColName(prob, iCol, buff, buffSize, pReqSize)
+    ccall((:COPT_GetColName, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cchar}, Cint, Ptr{Cint}), prob, iCol, buff, buffSize, pReqSize)
+end
+
+function COPT_GetPSDColName(prob, iPSDCol, buff, buffSize, pReqSize)
+    ccall((:COPT_GetPSDColName, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cchar}, Cint, Ptr{Cint}), prob, iPSDCol, buff, buffSize, pReqSize)
+end
+
+function COPT_GetRowName(prob, iRow, buff, buffSize, pReqSize)
+    ccall((:COPT_GetRowName, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cchar}, Cint, Ptr{Cint}), prob, iRow, buff, buffSize, pReqSize)
+end
+
+function COPT_GetQConstrName(prob, iQConstr, buff, buffSize, pReqSize)
+    ccall((:COPT_GetQConstrName, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cchar}, Cint, Ptr{Cint}), prob, iQConstr, buff, buffSize, pReqSize)
+end
+
+function COPT_GetPSDConstrName(prob, iPSDConstr, buff, buffSize, pReqSize)
+    ccall((:COPT_GetPSDConstrName, libcopt), Cint, (Ptr{copt_prob}, Cint, Ptr{Cchar}, Cint, Ptr{Cint}), prob, iPSDConstr, buff, buffSize, pReqSize)
+end
+
+function COPT_SetLogFile(prob, logfilename)
+    ccall((:COPT_SetLogFile, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cchar}), prob, logfilename)
+end
+
+function COPT_SetLogCallback(prob, logcb, userdata)
+    ccall((:COPT_SetLogCallback, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cvoid}, Ptr{Cvoid}), prob, logcb, userdata)
+end
+
+function COPT_SetCallback(prob, cb, cbctx, userdata)
+    ccall((:COPT_SetCallback, libcopt), Cint, (Ptr{copt_prob}, Ptr{Cvoid}, Cint, Ptr{Cvoid}), prob, cb, cbctx, userdata)
+end
+
+function COPT_GetCallbackInfo(cbdata, cbinfo, p_val)
+    ccall((:COPT_GetCallbackInfo, libcopt), Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cvoid}), cbdata, cbinfo, p_val)
+end
+
+function COPT_AddCallbackSolution(cbdata, sol, p_objval)
+    ccall((:COPT_AddCallbackSolution, libcopt), Cint, (Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cdouble}), cbdata, sol, p_objval)
+end
+
+function COPT_AddCallbackUserCut(cbdata, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowRhs)
+    ccall((:COPT_AddCallbackUserCut, libcopt), Cint, (Ptr{Cvoid}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cchar, Cdouble), cbdata, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowRhs)
+end
+
+function COPT_AddCallbackUserCuts(cbdata, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowRhs)
+    ccall((:COPT_AddCallbackUserCuts, libcopt), Cint, (Ptr{Cvoid}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}), cbdata, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowRhs)
+end
+
+function COPT_AddCallbackLazyConstr(cbdata, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowRhs)
+    ccall((:COPT_AddCallbackLazyConstr, libcopt), Cint, (Ptr{Cvoid}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cchar, Cdouble), cbdata, nRowMatCnt, rowMatIdx, rowMatElem, cRowSense, dRowRhs)
+end
+
+function COPT_AddCallbackLazyConstrs(cbdata, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowRhs)
+    ccall((:COPT_AddCallbackLazyConstrs, libcopt), Cint, (Ptr{Cvoid}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cchar}, Ptr{Cdouble}), cbdata, nAddRow, rowMatBeg, rowMatCnt, rowMatIdx, rowMatElem, rowSense, rowRhs)
+end
+
+function COPT_Interrupt(prob)
+    ccall((:COPT_Interrupt, libcopt), Cint, (Ptr{copt_prob},), prob)
+end
+
+const COPT_INT64 = Clong
+
+const COPT_VERSION_MAJOR = 6
+
+const COPT_VERSION_MINOR = 5
+
+const COPT_VERSION_TECHNICAL = 3
+
+const COPT_MINIMIZE = 1
+
+const COPT_MAXIMIZE = -1
+
+const COPT_INFINITY = 1.0e30
+
+const COPT_UNDEFINED = 1.0e40
+
+const COPT_BUFFSIZE = 1000
+
+const COPT_LESS_EQUAL = Cchar('L')
+
+const COPT_GREATER_EQUAL = Cchar('G')
+
+const COPT_EQUAL = Cchar('E')
+
+const COPT_FREE = Cchar('N')
+
+const COPT_RANGE = Cchar('R')
+
+const COPT_CONTINUOUS = Cchar('C')
+
+const COPT_BINARY = Cchar('B')
+
+const COPT_INTEGER = Cchar('I')
+
+const COPT_SOS_TYPE1 = 1
+
+const COPT_SOS_TYPE2 = 2
+
+const COPT_CONE_QUAD = 1
+
+const COPT_CONE_RQUAD = 2
+
+const COPT_RETCODE_OK = 0
+
+const COPT_RETCODE_MEMORY = 1
+
+const COPT_RETCODE_FILE = 2
+
+const COPT_RETCODE_INVALID = 3
+
+const COPT_RETCODE_LICENSE = 4
+
+const COPT_RETCODE_INTERNAL = 5
+
+const COPT_RETCODE_THREAD = 6
+
+const COPT_RETCODE_SERVER = 7
+
+const COPT_RETCODE_NONCONVEX = 8
+
+const COPT_BASIS_LOWER = 0
+
+const COPT_BASIS_BASIC = 1
+
+const COPT_BASIS_UPPER = 2
+
+const COPT_BASIS_SUPERBASIC = 3
+
+const COPT_BASIS_FIXED = 4
+
+const COPT_LPSTATUS_UNSTARTED = 0
+
+const COPT_LPSTATUS_OPTIMAL = 1
+
+const COPT_LPSTATUS_INFEASIBLE = 2
+
+const COPT_LPSTATUS_UNBOUNDED = 3
+
+const COPT_LPSTATUS_NUMERICAL = 5
+
+const COPT_LPSTATUS_IMPRECISE = 7
+
+const COPT_LPSTATUS_TIMEOUT = 8
+
+const COPT_LPSTATUS_UNFINISHED = 9
+
+const COPT_LPSTATUS_INTERRUPTED = 10
+
+const COPT_MIPSTATUS_UNSTARTED = 0
+
+const COPT_MIPSTATUS_OPTIMAL = 1
+
+const COPT_MIPSTATUS_INFEASIBLE = 2
+
+const COPT_MIPSTATUS_UNBOUNDED = 3
+
+const COPT_MIPSTATUS_INF_OR_UNB = 4
+
+const COPT_MIPSTATUS_NODELIMIT = 6
+
+const COPT_MIPSTATUS_TIMEOUT = 8
+
+const COPT_MIPSTATUS_UNFINISHED = 9
+
+const COPT_MIPSTATUS_INTERRUPTED = 10
+
+const COPT_CBCONTEXT_MIPRELAX = 0x01
+
+const COPT_CBCONTEXT_MIPSOL = 0x02
+
+const COPT_CBINFO_BESTOBJ = "BestObj"
+
+const COPT_CBINFO_BESTBND = "BestBnd"
+
+const COPT_CBINFO_HASINCUMBENT = "HasIncumbent"
+
+const COPT_CBINFO_INCUMBENT = "Incumbent"
+
+const COPT_CBINFO_MIPCANDIDATE = "MipCandidate"
+
+const COPT_CBINFO_MIPCANDOBJ = "MipCandObj"
+
+const COPT_CBINFO_RELAXSOLUTION = "RelaxSolution"
+
+const COPT_CBINFO_RELAXSOLOBJ = "RelaxSolObj"
+
+const COPT_DBLPARAM_TIMELIMIT = "TimeLimit"
+
+const COPT_DBLPARAM_MATRIXTOL = "MatrixTol"
+
+const COPT_DBLPARAM_FEASTOL = "FeasTol"
+
+const COPT_DBLPARAM_DUALTOL = "DualTol"
+
+const COPT_DBLPARAM_INTTOL = "IntTol"
+
+const COPT_DBLPARAM_RELGAP = "RelGap"
+
+const COPT_DBLPARAM_ABSGAP = "AbsGap"
+
+const COPT_DBLPARAM_TUNETIMELIMIT = "TuneTimeLimit"
+
+const COPT_DBLPARAM_TUNETARGETTIME = "TuneTargetTime"
+
+const COPT_DBLPARAM_TUNETARGETRELGAP = "TuneTargetRelGap"
+
+const COPT_INTPARAM_LOGGING = "Logging"
+
+const COPT_INTPARAM_LOGTOCONSOLE = "LogToConsole"
+
+const COPT_INTPARAM_PRESOLVE = "Presolve"
+
+const COPT_INTPARAM_SCALING = "Scaling"
+
+const COPT_INTPARAM_DUALIZE = "Dualize"
+
+const COPT_INTPARAM_LPMETHOD = "LpMethod"
+
+const COPT_INTPARAM_REQFARKASRAY = "ReqFarkasRay"
+
+const COPT_INTPARAM_DUALPRICE = "DualPrice"
+
+const COPT_INTPARAM_DUALPERTURB = "DualPerturb"
+
+const COPT_INTPARAM_CUTLEVEL = "CutLevel"
+
+const COPT_INTPARAM_ROOTCUTLEVEL = "RootCutLevel"
+
+const COPT_INTPARAM_TREECUTLEVEL = "TreeCutLevel"
+
+const COPT_INTPARAM_ROOTCUTROUNDS = "RootCutRounds"
+
+const COPT_INTPARAM_NODECUTROUNDS = "NodeCutRounds"
+
+const COPT_INTPARAM_HEURLEVEL = "HeurLevel"
+
+const COPT_INTPARAM_ROUNDINGHEURLEVEL = "RoundingHeurLevel"
+
+const COPT_INTPARAM_DIVINGHEURLEVEL = "DivingHeurLevel"
+
+const COPT_INTPARAM_SUBMIPHEURLEVEL = "SubMipHeurLevel"
+
+const COPT_INTPARAM_STRONGBRANCHING = "StrongBranching"
+
+const COPT_INTPARAM_CONFLICTANALYSIS = "ConflictAnalysis"
+
+const COPT_INTPARAM_NODELIMIT = "NodeLimit"
+
+const COPT_INTPARAM_MIPTASKS = "MipTasks"
+
+const COPT_INTPARAM_BARHOMOGENEOUS = "BarHomogeneous"
+
+const COPT_INTPARAM_BARORDER = "BarOrder"
+
+const COPT_INTPARAM_BARITERLIMIT = "BarIterLimit"
+
+const COPT_INTPARAM_THREADS = "Threads"
+
+const COPT_INTPARAM_BARTHREADS = "BarThreads"
+
+const COPT_INTPARAM_SIMPLEXTHREADS = "SimplexThreads"
+
+const COPT_INTPARAM_CROSSOVERTHREADS = "CrossoverThreads"
+
+const COPT_INTPARAM_CROSSOVER = "Crossover"
+
+const COPT_INTPARAM_SDPMETHOD = "SDPMethod"
+
+const COPT_INTPARAM_IISMETHOD = "IISMethod"
+
+const COPT_INTPARAM_FEASRELAXMODE = "FeasRelaxMode"
+
+const COPT_INTPARAM_MIPSTARTMODE = "MipStartMode"
+
+const COPT_INTPARAM_MIPSTARTNODELIMIT = "MipStartNodeLimit"
+
+const COPT_INTPARAM_TUNEMETHOD = "TuneMethod"
+
+const COPT_INTPARAM_TUNEMODE = "TuneMode"
+
+const COPT_INTPARAM_TUNEMEASURE = "TuneMeasure"
+
+const COPT_INTPARAM_TUNEPERMUTES = "TunePermutes"
+
+const COPT_INTPARAM_TUNEOUTPUTLEVEL = "TuneOutputLevel"
+
+const COPT_INTPARAM_LAZYCONSTRAINTS = "LazyConstraints"
+
+const COPT_DBLATTR_SOLVINGTIME = "SolvingTime"
+
+const COPT_DBLATTR_OBJCONST = "ObjConst"
+
+const COPT_DBLATTR_LPOBJVAL = "LpObjval"
+
+const COPT_DBLATTR_BESTOBJ = "BestObj"
+
+const COPT_DBLATTR_BESTBND = "BestBnd"
+
+const COPT_DBLATTR_BESTGAP = "BestGap"
+
+const COPT_DBLATTR_FEASRELAXOBJ = "FeasRelaxObj"
+
+const COPT_INTATTR_COLS = "Cols"
+
+const COPT_INTATTR_PSDCOLS = "PSDCols"
+
+const COPT_INTATTR_ROWS = "Rows"
+
+const COPT_INTATTR_ELEMS = "Elems"
+
+const COPT_INTATTR_QELEMS = "QElems"
+
+const COPT_INTATTR_PSDELEMS = "PSDElems"
+
+const COPT_INTATTR_SYMMATS = "SymMats"
+
+const COPT_INTATTR_BINS = "Bins"
+
+const COPT_INTATTR_INTS = "Ints"
+
+const COPT_INTATTR_SOSS = "Soss"
+
+const COPT_INTATTR_CONES = "Cones"
+
+const COPT_INTATTR_QCONSTRS = "QConstrs"
+
+const COPT_INTATTR_PSDCONSTRS = "PSDConstrs"
+
+const COPT_INTATTR_INDICATORS = "Indicators"
+
+const COPT_INTATTR_IISCOLS = "IISCols"
+
+const COPT_INTATTR_IISROWS = "IISRows"
+
+const COPT_INTATTR_IISSOSS = "IISSOSs"
+
+const COPT_INTATTR_IISINDICATORS = "IISIndicators"
+
+const COPT_INTATTR_OBJSENSE = "ObjSense"
+
+const COPT_INTATTR_LPSTATUS = "LpStatus"
+
+const COPT_INTATTR_MIPSTATUS = "MipStatus"
+
+const COPT_INTATTR_SIMPLEXITER = "SimplexIter"
+
+const COPT_INTATTR_BARRIERITER = "BarrierIter"
+
+const COPT_INTATTR_NODECNT = "NodeCnt"
+
+const COPT_INTATTR_POOLSOLS = "PoolSols"
+
+const COPT_INTATTR_TUNERESULTS = "TuneResults"
+
+const COPT_INTATTR_HASLPSOL = "HasLpSol"
+
+const COPT_INTATTR_HASDUALFARKAS = "HasDualFarkas"
+
+const COPT_INTATTR_HASPRIMALRAY = "HasPrimalRay"
+
+const COPT_INTATTR_HASBASIS = "HasBasis"
+
+const COPT_INTATTR_HASMIPSOL = "HasMipSol"
+
+const COPT_INTATTR_HASQOBJ = "HasQObj"
+
+const COPT_INTATTR_HASPSDOBJ = "HasPSDObj"
+
+const COPT_INTATTR_HASIIS = "HasIIS"
+
+const COPT_INTATTR_HASFEASRELAXSOL = "HasFeasRelaxSol"
+
+const COPT_INTATTR_ISMIP = "IsMIP"
+
+const COPT_INTATTR_ISMINIIS = "IsMinIIS"
+
+const COPT_DBLINFO_OBJ = "Obj"
+
+const COPT_DBLINFO_LB = "LB"
+
+const COPT_DBLINFO_UB = "UB"
+
+const COPT_DBLINFO_VALUE = "Value"
+
+const COPT_DBLINFO_SLACK = "Slack"
+
+const COPT_DBLINFO_DUAL = "Dual"
+
+const COPT_DBLINFO_REDCOST = "RedCost"
+
+const COPT_DBLINFO_DUALFARKAS = "DualFarkas"
+
+const COPT_DBLINFO_PRIMALRAY = "PrimalRay"
+
+const COPT_DBLINFO_RELAXLB = "RelaxLB"
+
+const COPT_DBLINFO_RELAXUB = "RelaxUB"
+
+const COPT_DBLINFO_RELAXVALUE = "RelaxValue"
+
+const COPT_CLIENT_CLUSTER = "Cluster"
+
+const COPT_CLIENT_FLOATING = "Floating"
+
+const COPT_CLIENT_PASSWORD = "PassWord"
+
+const COPT_CLIENT_PORT = "Port"
+
+const COPT_CLIENT_PRIORITY = "Priority"
+
+const COPT_CLIENT_WAITTIME = "WaitTime"
+

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -37,14 +37,17 @@ function test_runtests()
             "test_linear_Indicator_ON_ZERO",
             "test_linear_Indicator_constant_term",
             "test_linear_Indicator_integration",
+            # exclude tests that trigger bugs in COPT 6.5.x
+            "test_linear_Semiinteger_integration",
+            "test_linear_Semicontinuous_integration",
+            # IIS is not available for feasible model
+            "test_solve_conflict_feasible",
             # TODO(odow): new tests
             "test_unbounded_",
             "test_infeasible_",
             # COPT does not support nonconvex QCPs
             "test_quadratic_nonconvex_",
             "test_conic_SecondOrderCone_negative_post_bound_3",
-            # COPT does not support QP/QCP/SOCP with discrete variables
-            "test_quadratic_Integer_SecondOrderCone",
             # COPT does not support quadratic constraints with empty Q matrix
             "test_basic_VectorQuadraticFunction_GeometricMeanCone",
             # COPT does not provide dual solution for quadratic constraints

--- a/test/MathOptInterface/callback.jl
+++ b/test/MathOptInterface/callback.jl
@@ -1,0 +1,548 @@
+# Copyright (c) 2023: COPT-Public
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestCallback
+
+using COPT
+using MathOptInterface
+using Random
+using Test
+
+const MOI = MathOptInterface
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function callback_simple_model()
+    env = COPT.Env()
+    model = COPT.Optimizer(env)
+    MOI.set(model, MOI.RawOptimizerAttribute("LogToConsole"), 0)
+    MOI.Utilities.loadfromstring!(
+        model,
+        """
+    variables: x, y
+    maxobjective: y
+    c1: x in Integer()
+    c2: y in Integer()
+    c3: x in Interval(0.0, 2.5)
+    c4: y in Interval(0.0, 2.5)
+""",
+    )
+    x = MOI.get(model, MOI.VariableIndex, "x")
+    y = MOI.get(model, MOI.VariableIndex, "y")
+    return model, x, y
+end
+
+function callback_knapsack_model()
+    env = COPT.Env()
+    model = COPT.Optimizer(env)
+    MOI.set(model, MOI.RawOptimizerAttribute("LogToConsole"), 0)
+    N = 30
+    x = MOI.add_variables(model, N)
+    MOI.add_constraints(model, x, MOI.ZeroOne())
+    MOI.set.(model, MOI.VariablePrimalStart(), x, 0.0)
+    Random.seed!(1)
+    item_weights, item_values = rand(N), rand(N)
+    MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(item_weights, x), 0.0),
+        MOI.LessThan(10.0),
+    )
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(item_values, x), 0.0),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    return model, x, item_weights
+end
+
+# function test_lazy_constraint_callback()
+#     model, x, y = callback_simple_model()
+#     lazy_called = false
+#     MOI.set(
+#         model,
+#         MOI.LazyConstraintCallback(),
+#         cb_data -> begin
+#             lazy_called = true
+#             x_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+#             y_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y)
+#             status = MOI.get(
+#                 model,
+#                 MOI.CallbackNodeStatus(cb_data),
+#             )::MOI.CallbackNodeStatusCode
+#             int_sol = round.(Int, [x_val, y_val])
+#             if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+#                 @test isapprox(int_sol, [x_val, y_val], atol = 1e-6)
+#             end
+#             @test MOI.supports(model, MOI.LazyConstraint(cb_data))
+#             if y_val - x_val > 1 + 1e-6
+#                 @test MOI.submit(
+#                     model,
+#                     MOI.LazyConstraint(cb_data),
+#                     MOI.ScalarAffineFunction{Float64}(
+#                         MOI.ScalarAffineTerm.([-1.0, 1.0], [x, y]),
+#                         0.0,
+#                     ),
+#                     MOI.LessThan{Float64}(1.0),
+#                 ) === nothing
+#             elseif y_val + x_val > 3 + 1e-6
+#                 @test MOI.submit(
+#                     model,
+#                     MOI.LazyConstraint(cb_data),
+#                     MOI.ScalarAffineFunction{Float64}(
+#                         MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
+#                         0.0,
+#                     ),
+#                     MOI.LessThan{Float64}(3.0),
+#                 ) === nothing
+#             end
+#         end,
+#     )
+#     @test MOI.supports(model, MOI.LazyConstraintCallback())
+#     MOI.optimize!(model)
+#     @test lazy_called
+#     @test MOI.get(model, MOI.VariablePrimal(), x) == 1
+#     @test MOI.get(model, MOI.VariablePrimal(), y) == 2
+# end
+
+# function test_lazy_constraint_callback_fractional()
+#     model, x, item_weights = callback_knapsack_model()
+#     lazy_called_integer = false
+#     lazy_called_fractional = false
+#     MOI.set(
+#         model,
+#         MOI.LazyConstraintCallback(),
+#         cb_data -> begin
+#             status = MOI.get(
+#                 model,
+#                 MOI.CallbackNodeStatus(cb_data),
+#             )::MOI.CallbackNodeStatusCode
+#             if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+#                 lazy_called_integer = true
+#             elseif status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+#                 lazy_called_fractional = true
+#             end
+#         end,
+#     )
+#     @test MOI.supports(model, MOI.LazyConstraintCallback())
+#     MOI.optimize!(model)
+#     @test lazy_called_integer || lazy_called_fractional
+# end
+
+function test_lazy_constraint_callback_OptimizeInProgress()
+    model, x, y = callback_simple_model()
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        cb_data -> begin
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.VariablePrimal()),
+                MOI.get(model, MOI.VariablePrimal(), x)
+            )
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.ObjectiveValue()),
+                MOI.get(model, MOI.ObjectiveValue())
+            )
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.ObjectiveBound()),
+                MOI.get(model, MOI.ObjectiveBound())
+            )
+        end,
+    )
+    return MOI.optimize!(model)
+end
+
+function test_lazy_constraint_callback_UserCut()
+    model, x, y = callback_simple_model()
+    cb = nothing
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        cb_data -> begin
+            cb = cb_data
+            MOI.submit(
+                model,
+                MOI.UserCut(cb_data),
+                MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0),
+                MOI.LessThan(2.0),
+            )
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(MOI.LazyConstraintCallback(), MOI.UserCut(cb)),
+        MOI.optimize!(model)
+    )
+end
+
+function test_lazy_constraint_callback_HeuristicSolution()
+    model, x, y = callback_simple_model()
+    cb = nothing
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        cb_data -> begin
+            cb = cb_data
+            MOI.submit(model, MOI.HeuristicSolution(cb_data), [x], [2.0])
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(
+            MOI.LazyConstraintCallback(),
+            MOI.HeuristicSolution(cb),
+        ),
+        MOI.optimize!(model)
+    )
+end
+
+# function test_user_cut_callback()
+#     model, x, item_weights = callback_knapsack_model()
+#     user_cut_submitted = false
+#     MOI.set(
+#         model,
+#         MOI.UserCutCallback(),
+#         cb_data -> begin
+#             terms = MOI.ScalarAffineTerm{Float64}[]
+#             accumulated = 0.0
+#             for (i, xi) in enumerate(x)
+#                 if MOI.get(model, MOI.CallbackVariablePrimal(cb_data), xi) > 0.0
+#                     push!(terms, MOI.ScalarAffineTerm(1.0, xi))
+#                     accumulated += item_weights[i]
+#                 end
+#             end
+#             @test MOI.supports(model, MOI.UserCut(cb_data))
+#             if accumulated > 10.0
+#                 @test MOI.submit(
+#                     model,
+#                     MOI.UserCut(cb_data),
+#                     MOI.ScalarAffineFunction{Float64}(terms, 0.0),
+#                     MOI.LessThan{Float64}(length(terms) - 1),
+#                 ) === nothing
+#                 user_cut_submitted = true
+#             end
+#         end,
+#     )
+#     @test MOI.supports(model, MOI.UserCutCallback())
+#     MOI.optimize!(model)
+#     @test user_cut_submitted
+# end
+
+# function test_user_cut_callback_LazyConstraint()
+#     model, x, item_weights = callback_knapsack_model()
+#     cb = nothing
+#     MOI.set(
+#         model,
+#         MOI.UserCutCallback(),
+#         cb_data -> begin
+#             cb = cb_data
+#             MOI.submit(
+#                 model,
+#                 MOI.LazyConstraint(cb_data),
+#                 MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
+#                 MOI.LessThan(5.0),
+#             )
+#         end,
+#     )
+#     @test_throws(
+#         MOI.InvalidCallbackUsage(MOI.UserCutCallback(), MOI.LazyConstraint(cb)),
+#         MOI.optimize!(model)
+#     )
+# end
+
+# function test_user_cut_callback_HeuristicSolution()
+#     model, x, item_weights = callback_knapsack_model()
+#     cb = nothing
+#     MOI.set(
+#         model,
+#         MOI.UserCutCallback(),
+#         cb_data -> begin
+#             cb = cb_data
+#             MOI.submit(model, MOI.HeuristicSolution(cb_data), [x[1]], [0.0])
+#         end,
+#     )
+#     @test_throws(
+#         MOI.InvalidCallbackUsage(
+#             MOI.UserCutCallback(),
+#             MOI.HeuristicSolution(cb),
+#         ),
+#         MOI.optimize!(model)
+#     )
+# end
+
+# function test_heuristic_callback()
+#     model, x, item_weights = callback_knapsack_model()
+#     solution_accepted = false
+#     solution_rejected = false
+#     MOI.set(
+#         model,
+#         MOI.HeuristicCallback(),
+#         cb_data -> begin
+#             x_vals = MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
+#             @test MOI.supports(model, MOI.HeuristicSolution(cb_data))
+#             status = MOI.get(
+#                 model,
+#                 MOI.CallbackNodeStatus(cb_data),
+#             )::MOI.CallbackNodeStatusCode
+#             int_sol = round.(Int, x_vals)
+#             if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+#                 @test isapprox(int_sol, x_vals, atol = 1e-6)
+#             end
+#             if MOI.submit(
+#                 model,
+#                 MOI.HeuristicSolution(cb_data),
+#                 x,
+#                 floor.(x_vals),
+#             ) == MOI.HEURISTIC_SOLUTION_ACCEPTED
+#                 solution_accepted = true
+#             end
+#             if MOI.submit(
+#                 model,
+#                 MOI.HeuristicSolution(cb_data),
+#                 x,
+#                 ceil.(x_vals),
+#             ) == MOI.HEURISTIC_SOLUTION_REJECTED
+#                 solution_rejected = true
+#             end
+#         end,
+#     )
+#     @test MOI.supports(model, MOI.HeuristicCallback())
+#     MOI.optimize!(model)
+#     @test solution_accepted || solution_rejected
+# end
+
+function test_heuristic_callback_LazyConstraint()
+    model, x, item_weights = callback_knapsack_model()
+    cb = nothing
+    MOI.set(
+        model,
+        MOI.HeuristicCallback(),
+        cb_data -> begin
+            cb = cb_data
+            MOI.submit(
+                model,
+                MOI.LazyConstraint(cb_data),
+                MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
+                MOI.LessThan(5.0),
+            )
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(
+            MOI.HeuristicCallback(),
+            MOI.LazyConstraint(cb),
+        ),
+        MOI.optimize!(model)
+    )
+end
+
+function test_heuristic_callback_UserCut()
+    model, x, item_weights = callback_knapsack_model()
+    cb = nothing
+    MOI.set(
+        model,
+        MOI.HeuristicCallback(),
+        cb_data -> begin
+            cb = cb_data
+            MOI.submit(
+                model,
+                MOI.UserCut(cb_data),
+                MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
+                MOI.LessThan(5.0),
+            )
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(MOI.HeuristicCallback(), MOI.UserCut(cb)),
+        MOI.optimize!(model)
+    )
+end
+
+function test_CallbackFunction_callback_OptimizeInProgress()
+    model, x, y = callback_simple_model()
+    MOI.set(
+        model,
+        COPT.CallbackFunction(),
+        (cb_data, cb_context) -> begin
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.VariablePrimal()),
+                MOI.get(model, MOI.VariablePrimal(), x)
+            )
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.ObjectiveValue()),
+                MOI.get(model, MOI.ObjectiveValue())
+            )
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.ObjectiveBound()),
+                MOI.get(model, MOI.ObjectiveBound())
+            )
+        end,
+    )
+    @test MOI.supports(model, COPT.CallbackFunction())
+    return MOI.optimize!(model)
+end
+
+function test_CallbackFunction_callback_LazyConstraint()
+    model, x, y = callback_simple_model()
+    cb_calls = Int32[]
+    function callback_function(cb_data::COPT.CallbackData, cb_context::Cint)
+        push!(cb_calls, cb_context)
+        if cb_context == COPT.COPT_CBCONTEXT_MIPSOL
+            COPT.load_callback_variable_primal(cb_data, cb_context)
+            x_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+            y_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y)
+            if y_val - x_val > 1 + 1e-6
+                MOI.submit(
+                    model,
+                    MOI.LazyConstraint(cb_data),
+                    MOI.ScalarAffineFunction{Float64}(
+                        MOI.ScalarAffineTerm.([-1.0, 1.0], [x, y]),
+                        0.0,
+                    ),
+                    MOI.LessThan{Float64}(1.0),
+                )
+            elseif y_val + x_val > 3 + 1e-6
+                MOI.submit(
+                    model,
+                    MOI.LazyConstraint(cb_data),
+                    MOI.ScalarAffineFunction{Float64}(
+                        MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
+                        0.0,
+                    ),
+                    MOI.LessThan{Float64}(3.0),
+                )
+            end
+        end
+    end
+    MOI.set(model, COPT.CallbackFunction(), callback_function)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.VariablePrimal(), x) == 1
+    @test MOI.get(model, MOI.VariablePrimal(), y) == 2
+    @test length(cb_calls) > 0
+    @test COPT.COPT_CBCONTEXT_MIPSOL in cb_calls
+end
+
+# function test_CallbackFunction_callback_UserCut()
+#     model, x, item_weights = callback_knapsack_model()
+#     user_cut_submitted = false
+#     cb_calls = Int32[]
+#     MOI.set(
+#         model,
+#         COPT.CallbackFunction(),
+#         (cb_data, cb_context) -> begin
+#             push!(cb_calls, cb_context)
+#             if cb_context != COPT.COPT_CBCONTEXT_MIPRELAX
+#                 return
+#             end
+#             COPT.load_callback_variable_primal(cb_data, cb_context)
+#             terms = MOI.ScalarAffineTerm{Float64}[]
+#             accumulated = 0.0
+#             for (i, xi) in enumerate(x)
+#                 if MOI.get(model, MOI.CallbackVariablePrimal(cb_data), xi) > 0.0
+#                     push!(terms, MOI.ScalarAffineTerm(1.0, xi))
+#                     accumulated += item_weights[i]
+#                 end
+#             end
+#             if accumulated > 10.0
+#                 MOI.submit(
+#                     model,
+#                     MOI.UserCut(cb_data),
+#                     MOI.ScalarAffineFunction{Float64}(terms, 0.0),
+#                     MOI.LessThan{Float64}(length(terms) - 1),
+#                 )
+#                 user_cut_submitted = true
+#             end
+#         end,
+#     )
+#     MOI.optimize!(model)
+#     @test user_cut_submitted
+#     @test COPT.COPT_CBCONTEXT_MIPRELAX in cb_calls
+# end
+
+# function test_CallbackFunction_callback_HeuristicSolution()
+#     model, x, item_weights = callback_knapsack_model()
+#     solution_accepted = false
+#     solution_rejected = false
+#     solution_unknown = false
+#     cb_calls = Int32[]
+#     MOI.set(
+#         model,
+#         COPT.CallbackFunction(),
+#         (cb_data, cb_context) -> begin
+#             push!(cb_calls, cb_context)
+#             if cb_context != COPT.COPT_CBCONTEXT_MIPRELAX
+#                 return
+#             end
+#             COPT.load_callback_variable_primal(cb_data, cb_context)
+#             x_vals =
+#                 MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
+#             if MOI.submit(
+#                 model,
+#                 MOI.HeuristicSolution(cb_data),
+#                 x,
+#                 floor.(x_vals),
+#             ) == MOI.HEURISTIC_SOLUTION_ACCEPTED
+#                 solution_accepted = true
+#             end
+#             if MOI.submit(
+#                 model,
+#                 MOI.HeuristicSolution(cb_data),
+#                 x,
+#                 ceil.(x_vals),
+#             ) == MOI.HEURISTIC_SOLUTION_REJECTED
+#                 solution_rejected = true
+#             end
+#         end,
+#     )
+#     MOI.optimize!(model)
+#     @test solution_accepted || solution_rejected || solution_unknown
+# end
+
+# function test_CallbackFunction_CallbackNodeStatus()
+#     model, x, item_weights = callback_knapsack_model()
+#     unknown_reached = false
+#     MOI.set(
+#         model,
+#         COPT.CallbackFunction(),
+#         (cb_data, cb_context) -> begin
+#             if MOI.get(model, MOI.CallbackNodeStatus(cb_data)) ==
+#                MOI.CALLBACK_NODE_STATUS_UNKNOWN
+#                 unknown_reached = true
+#             end
+#         end,
+#     )
+#     MOI.optimize!(model)
+#     @test unknown_reached
+# end
+
+# function test_CallbackFunction_broadcast()
+#     model, x, _ = callback_knapsack_model()
+#     f(cb_data, x) = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+#     solutions = Vector{Float64}[]
+#     MOI.set(
+#         model,
+#         COPT.CallbackFunction(),
+#         (cb_data, cb_context) -> begin
+#             if cb_context == COPT.COPT_CBCONTEXT_MIPSOL
+#                 COPT.load_callback_variable_primal(cb_data, cb_context)
+#                 push!(solutions, f(cb_data, x))
+#             end
+#         end,
+#     )
+#     MOI.optimize!(model)
+#     @test length(solutions) > 0
+#     @test length(solutions[1]) == length(x)
+# end
+
+end  # module TestCallback
+
+TestCallback.runtests()

--- a/test/MathOptInterface/callback.jl
+++ b/test/MathOptInterface/callback.jl
@@ -67,78 +67,78 @@ function callback_knapsack_model()
     return model, x, item_weights
 end
 
-# function test_lazy_constraint_callback()
-#     model, x, y = callback_simple_model()
-#     lazy_called = false
-#     MOI.set(
-#         model,
-#         MOI.LazyConstraintCallback(),
-#         cb_data -> begin
-#             lazy_called = true
-#             x_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
-#             y_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y)
-#             status = MOI.get(
-#                 model,
-#                 MOI.CallbackNodeStatus(cb_data),
-#             )::MOI.CallbackNodeStatusCode
-#             int_sol = round.(Int, [x_val, y_val])
-#             if status == MOI.CALLBACK_NODE_STATUS_INTEGER
-#                 @test isapprox(int_sol, [x_val, y_val], atol = 1e-6)
-#             end
-#             @test MOI.supports(model, MOI.LazyConstraint(cb_data))
-#             if y_val - x_val > 1 + 1e-6
-#                 @test MOI.submit(
-#                     model,
-#                     MOI.LazyConstraint(cb_data),
-#                     MOI.ScalarAffineFunction{Float64}(
-#                         MOI.ScalarAffineTerm.([-1.0, 1.0], [x, y]),
-#                         0.0,
-#                     ),
-#                     MOI.LessThan{Float64}(1.0),
-#                 ) === nothing
-#             elseif y_val + x_val > 3 + 1e-6
-#                 @test MOI.submit(
-#                     model,
-#                     MOI.LazyConstraint(cb_data),
-#                     MOI.ScalarAffineFunction{Float64}(
-#                         MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
-#                         0.0,
-#                     ),
-#                     MOI.LessThan{Float64}(3.0),
-#                 ) === nothing
-#             end
-#         end,
-#     )
-#     @test MOI.supports(model, MOI.LazyConstraintCallback())
-#     MOI.optimize!(model)
-#     @test lazy_called
-#     @test MOI.get(model, MOI.VariablePrimal(), x) == 1
-#     @test MOI.get(model, MOI.VariablePrimal(), y) == 2
-# end
+function test_lazy_constraint_callback()
+    model, x, y = callback_simple_model()
+    lazy_called = false
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        cb_data -> begin
+            lazy_called = true
+            x_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+            y_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y)
+            status = MOI.get(
+                model,
+                MOI.CallbackNodeStatus(cb_data),
+            )::MOI.CallbackNodeStatusCode
+            int_sol = round.(Int, [x_val, y_val])
+            if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+                @test isapprox(int_sol, [x_val, y_val], atol = 1e-6)
+            end
+            @test MOI.supports(model, MOI.LazyConstraint(cb_data))
+            if y_val - x_val > 1 + 1e-6
+                @test MOI.submit(
+                    model,
+                    MOI.LazyConstraint(cb_data),
+                    MOI.ScalarAffineFunction{Float64}(
+                        MOI.ScalarAffineTerm.([-1.0, 1.0], [x, y]),
+                        0.0,
+                    ),
+                    MOI.LessThan{Float64}(1.0),
+                ) === nothing
+            elseif y_val + x_val > 3 + 1e-6
+                @test MOI.submit(
+                    model,
+                    MOI.LazyConstraint(cb_data),
+                    MOI.ScalarAffineFunction{Float64}(
+                        MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
+                        0.0,
+                    ),
+                    MOI.LessThan{Float64}(3.0),
+                ) === nothing
+            end
+        end,
+    )
+    @test MOI.supports(model, MOI.LazyConstraintCallback())
+    MOI.optimize!(model)
+    @test lazy_called
+    @test MOI.get(model, MOI.VariablePrimal(), x) == 1
+    @test MOI.get(model, MOI.VariablePrimal(), y) == 2
+end
 
-# function test_lazy_constraint_callback_fractional()
-#     model, x, item_weights = callback_knapsack_model()
-#     lazy_called_integer = false
-#     lazy_called_fractional = false
-#     MOI.set(
-#         model,
-#         MOI.LazyConstraintCallback(),
-#         cb_data -> begin
-#             status = MOI.get(
-#                 model,
-#                 MOI.CallbackNodeStatus(cb_data),
-#             )::MOI.CallbackNodeStatusCode
-#             if status == MOI.CALLBACK_NODE_STATUS_INTEGER
-#                 lazy_called_integer = true
-#             elseif status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
-#                 lazy_called_fractional = true
-#             end
-#         end,
-#     )
-#     @test MOI.supports(model, MOI.LazyConstraintCallback())
-#     MOI.optimize!(model)
-#     @test lazy_called_integer || lazy_called_fractional
-# end
+function test_lazy_constraint_callback_fractional()
+    model, x, item_weights = callback_knapsack_model()
+    lazy_called_integer = false
+    lazy_called_fractional = false
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        cb_data -> begin
+            status = MOI.get(
+                model,
+                MOI.CallbackNodeStatus(cb_data),
+            )::MOI.CallbackNodeStatusCode
+            if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+                lazy_called_integer = true
+            elseif status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+                lazy_called_fractional = true
+            end
+        end,
+    )
+    @test MOI.supports(model, MOI.LazyConstraintCallback())
+    MOI.optimize!(model)
+    @test lazy_called_integer || lazy_called_fractional
+end
 
 function test_lazy_constraint_callback_OptimizeInProgress()
     model, x, y = callback_simple_model()
@@ -279,46 +279,34 @@ end
 #     )
 # end
 
-# function test_heuristic_callback()
-#     model, x, item_weights = callback_knapsack_model()
-#     solution_accepted = false
-#     solution_rejected = false
-#     MOI.set(
-#         model,
-#         MOI.HeuristicCallback(),
-#         cb_data -> begin
-#             x_vals = MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
-#             @test MOI.supports(model, MOI.HeuristicSolution(cb_data))
-#             status = MOI.get(
-#                 model,
-#                 MOI.CallbackNodeStatus(cb_data),
-#             )::MOI.CallbackNodeStatusCode
-#             int_sol = round.(Int, x_vals)
-#             if status == MOI.CALLBACK_NODE_STATUS_INTEGER
-#                 @test isapprox(int_sol, x_vals, atol = 1e-6)
-#             end
-#             if MOI.submit(
-#                 model,
-#                 MOI.HeuristicSolution(cb_data),
-#                 x,
-#                 floor.(x_vals),
-#             ) == MOI.HEURISTIC_SOLUTION_ACCEPTED
-#                 solution_accepted = true
-#             end
-#             if MOI.submit(
-#                 model,
-#                 MOI.HeuristicSolution(cb_data),
-#                 x,
-#                 ceil.(x_vals),
-#             ) == MOI.HEURISTIC_SOLUTION_REJECTED
-#                 solution_rejected = true
-#             end
-#         end,
-#     )
-#     @test MOI.supports(model, MOI.HeuristicCallback())
-#     MOI.optimize!(model)
-#     @test solution_accepted || solution_rejected
-# end
+function test_heuristic_callback()
+    model, x, item_weights = callback_knapsack_model()
+    MOI.set(
+        model,
+        MOI.HeuristicCallback(),
+        cb_data -> begin
+            x_vals = MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
+            @test MOI.supports(model, MOI.HeuristicSolution(cb_data))
+            status = MOI.get(
+                model,
+                MOI.CallbackNodeStatus(cb_data),
+            )::MOI.CallbackNodeStatusCode
+            int_sol = round.(Int, x_vals)
+            if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+                @test isapprox(int_sol, x_vals, atol = 1e-6)
+            end
+            MOI.submit(
+                model,
+                MOI.HeuristicSolution(cb_data),
+                x,
+                floor.(x_vals),
+            )
+            MOI.submit(model, MOI.HeuristicSolution(cb_data), x, ceil.(x_vals))
+        end,
+    )
+    @test MOI.supports(model, MOI.HeuristicCallback())
+    return MOI.optimize!(model)
+end
 
 function test_heuristic_callback_LazyConstraint()
     model, x, item_weights = callback_knapsack_model()
@@ -468,80 +456,64 @@ end
 #     @test COPT.COPT_CBCONTEXT_MIPRELAX in cb_calls
 # end
 
-# function test_CallbackFunction_callback_HeuristicSolution()
-#     model, x, item_weights = callback_knapsack_model()
-#     solution_accepted = false
-#     solution_rejected = false
-#     solution_unknown = false
-#     cb_calls = Int32[]
-#     MOI.set(
-#         model,
-#         COPT.CallbackFunction(),
-#         (cb_data, cb_context) -> begin
-#             push!(cb_calls, cb_context)
-#             if cb_context != COPT.COPT_CBCONTEXT_MIPRELAX
-#                 return
-#             end
-#             COPT.load_callback_variable_primal(cb_data, cb_context)
-#             x_vals =
-#                 MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
-#             if MOI.submit(
-#                 model,
-#                 MOI.HeuristicSolution(cb_data),
-#                 x,
-#                 floor.(x_vals),
-#             ) == MOI.HEURISTIC_SOLUTION_ACCEPTED
-#                 solution_accepted = true
-#             end
-#             if MOI.submit(
-#                 model,
-#                 MOI.HeuristicSolution(cb_data),
-#                 x,
-#                 ceil.(x_vals),
-#             ) == MOI.HEURISTIC_SOLUTION_REJECTED
-#                 solution_rejected = true
-#             end
-#         end,
-#     )
-#     MOI.optimize!(model)
-#     @test solution_accepted || solution_rejected || solution_unknown
-# end
+function test_CallbackFunction_callback_HeuristicSolution()
+    model, x, item_weights = callback_knapsack_model()
+    cb_calls = Int32[]
+    MOI.set(
+        model,
+        COPT.CallbackFunction(),
+        (cb_data, cb_context) -> begin
+            push!(cb_calls, cb_context)
+            COPT.load_callback_variable_primal(cb_data, cb_context)
+            x_vals =
+                MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
+            MOI.submit(
+                model,
+                MOI.HeuristicSolution(cb_data),
+                x,
+                floor.(x_vals),
+            )
+        end,
+    )
+    MOI.optimize!(model)
+    @test COPT.COPT_CBCONTEXT_MIPSOL in cb_calls
+end
 
-# function test_CallbackFunction_CallbackNodeStatus()
-#     model, x, item_weights = callback_knapsack_model()
-#     unknown_reached = false
-#     MOI.set(
-#         model,
-#         COPT.CallbackFunction(),
-#         (cb_data, cb_context) -> begin
-#             if MOI.get(model, MOI.CallbackNodeStatus(cb_data)) ==
-#                MOI.CALLBACK_NODE_STATUS_UNKNOWN
-#                 unknown_reached = true
-#             end
-#         end,
-#     )
-#     MOI.optimize!(model)
-#     @test unknown_reached
-# end
+function test_CallbackFunction_CallbackNodeStatus()
+    model, x, item_weights = callback_knapsack_model()
+    unknown_reached = false
+    MOI.set(
+        model,
+        COPT.CallbackFunction(),
+        (cb_data, cb_context) -> begin
+            if MOI.get(model, MOI.CallbackNodeStatus(cb_data)) ==
+               MOI.CALLBACK_NODE_STATUS_UNKNOWN
+                unknown_reached = true
+            end
+        end,
+    )
+    MOI.optimize!(model)
+    @test !unknown_reached
+end
 
-# function test_CallbackFunction_broadcast()
-#     model, x, _ = callback_knapsack_model()
-#     f(cb_data, x) = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
-#     solutions = Vector{Float64}[]
-#     MOI.set(
-#         model,
-#         COPT.CallbackFunction(),
-#         (cb_data, cb_context) -> begin
-#             if cb_context == COPT.COPT_CBCONTEXT_MIPSOL
-#                 COPT.load_callback_variable_primal(cb_data, cb_context)
-#                 push!(solutions, f(cb_data, x))
-#             end
-#         end,
-#     )
-#     MOI.optimize!(model)
-#     @test length(solutions) > 0
-#     @test length(solutions[1]) == length(x)
-# end
+function test_CallbackFunction_broadcast()
+    model, x, _ = callback_knapsack_model()
+    f(cb_data, x) = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+    solutions = Vector{Float64}[]
+    MOI.set(
+        model,
+        COPT.CallbackFunction(),
+        (cb_data, cb_context) -> begin
+            if cb_context == COPT.COPT_CBCONTEXT_MIPSOL
+                COPT.load_callback_variable_primal(cb_data, cb_context)
+                push!(solutions, f(cb_data, x))
+            end
+        end,
+    )
+    MOI.optimize!(model)
+    @test length(solutions) > 0
+    @test length(solutions[1]) == length(x)
+end
 
 end  # module TestCallback
 

--- a/test/MathOptInterface/cone_optimizer.jl
+++ b/test/MathOptInterface/cone_optimizer.jl
@@ -50,7 +50,16 @@ function test_runtests()
             ],
         ),
         exclude = String[
-        # Expected test failures:
+            # exclude tests trigger failures with COPT 6.5.x (until 6.5.3):
+            "test_conic_HermitianPositiveSemidefiniteConeTriangle_2",
+            "test_conic_PositiveSemidefiniteConeSquare_VectorAffineFunction_2",
+            "test_conic_PositiveSemidefiniteConeSquare_VectorOfVariables_2",
+            "test_conic_PositiveSemidefiniteConeTriangle_VectorAffineFunction_2",
+            "test_conic_PositiveSemidefiniteConeTriangle_VectorOfVariables_2",
+            "test_conic_RootDetConeSquare",
+            "test_conic_RootDetConeTriangle",
+            "test_conic_RootDetConeTriangle_VectorAffineFunction",
+            "test_conic_RootDetConeTriangle_VectorOfVariables",
         ],
     )
     return


### PR DESCRIPTION
Updates for COPT 6.5, including callback functionality for MIP solver and IIS.    Some callback tests crash randomly in Julia 1.6.7,  but pass in Julia 1.9.0.   This issue might be caused internally by Julia 1.6.7, but we have not been able figure out the root of the problem.