### PR TITLE
Fix rounding in test_heuristic_callback

### DIFF
--- a/test/MathOptInterface/callback.jl
+++ b/test/MathOptInterface/callback.jl
@@ -81,8 +81,8 @@ function test_lazy_constraint_callback()
                 model,
                 MOI.CallbackNodeStatus(cb_data),
             )::MOI.CallbackNodeStatusCode
-            int_sol = round.(Int, [x_val, y_val])
             if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+                int_sol = round.(Int, [x_val, y_val])
                 @test isapprox(int_sol, [x_val, y_val], atol = 1e-6)
             end
             @test MOI.supports(model, MOI.LazyConstraint(cb_data))
@@ -291,8 +291,8 @@ function test_heuristic_callback()
                 model,
                 MOI.CallbackNodeStatus(cb_data),
             )::MOI.CallbackNodeStatusCode
-            int_sol = round.(Int, x_vals)
             if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+                int_sol = round.(Int, x_vals)
                 @test isapprox(int_sol, x_vals, atol = 1e-6)
             end
             MOI.submit(


### PR DESCRIPTION
I have seen the occasional failure in MOI's tests of third-party packages: https://github.com/jump-dev/MathOptInterface.jl/actions/runs/9539455292/job/26289809582

If the solution is not integer, then `x_vals` may contain a very large float that is not representable in `Int64`, and so `round` errors. We should try to round the solution only if the status is integer.